### PR TITLE
Remove unused variable

### DIFF
--- a/src/matio.h
+++ b/src/matio.h
@@ -94,7 +94,6 @@ enum matio_types {
     MAT_T_UTF16      = 17,    /**< @brief 16-bit unicode text data type       */
     MAT_T_UTF32      = 18,    /**< @brief 32-bit unicode text data type       */
 
-    MAT_T_STRING     = 20,    /**< @brief String data type                    */
     MAT_T_CELL       = 21,    /**< @brief Cell array data type                */
     MAT_T_STRUCT     = 22,    /**< @brief Structure data type                 */
     MAT_T_ARRAY      = 23,    /**< @brief Array data type                     */


### PR DESCRIPTION
MAT_T_STRING is nowhere used
To store strings use MAT_T_UTF8
